### PR TITLE
Fixed default reference in fracplot

### DIFF
--- a/R/fracplot.R
+++ b/R/fracplot.R
@@ -66,8 +66,8 @@ fracplot <- function(model,
   if (!inherits(model, "mfp2")) 
     stop("The model entered is not an mfp2 object.", call. = FALSE)
   
- # check if ref is a list 
-  if (!is.list(ref))
+ # check if ref is a list (only if it is not NULL)
+  if (!is.null(ref) && !is.list(ref))
     stop("ref must be a list", call. = F)
   
  # set defaults depending on type


### PR DESCRIPTION
Hi,
I think I found a bug in `fracplot()`. If `ref = NULL`, I would always get the "ref must be a list" error. But I think I should only get this error if I specified my own reference value not as a list. For example, see the code below:

```
# load data
data(GBSG, package = "mfp")

# create model matrix
X <- model.matrix(
  Surv(rfst, cens) ~ age+tumsize+posnodal+prm+esm+menostat+tumgrad,
  data = GBSG
)
X <- X[, -1] # exclude intercept

# create outcome
y <- with(GBSG, Surv(rfst, cens))

# fit mfp model
fit.mfp2 <- mfp2::mfp2(X, y, family = "cox", verbose = FALSE,
                       strata = GBSG$htreat,
                       select = 0.05, alpha = 0.05)
# plot terms
mfp2::fracplot(fit.mfp2, type = "terms", terms = "age")
```
I fixed this by only checking whether `ref` is a list if it is not `NULL`. Let me know what you think.


